### PR TITLE
Set up GitHub Actions to automatically release on each commit

### DIFF
--- a/.github/workflows/compress-and-release.yml
+++ b/.github/workflows/compress-and-release.yml
@@ -1,0 +1,33 @@
+name: Compress and Release
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  compress-and-release:
+    name: Compress and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        
+        # Credit to Pexien
+      - name: Compress datapacks
+        shell: pwsh
+        run: |
+          $dirs = Get-ChildItem -Directory -Recurse -Depth 1 | Where { !$_.Name.StartsWith(".") -and $_.Name.StartsWith("mcpeachpies") }
+          $dirs | ForEach { Compress-Archive -PassThru -Path "$_/*"  -DestinationPath "$pwd/$($_.Name).zip" }
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ github.run_id }} ${{ github.event.head_commit.message }}
+          tag_name: v${{ github.run_id }}
+          files: "*.zip"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every time a commit is pushed, a new release should be created (within 30-60s) that has each datapack's .zip file, assuming the following folder structure:
```
root
└── datapack_name/
    ├── mcpeachpies_datapack_name/
    ├── mcpeachpies_datapack_name_variation_etc/
    └── website.json
... more datapacks ...
```

![image](https://user-images.githubusercontent.com/22878174/121283220-9d4ed580-c88f-11eb-9560-3f8b169d2b09.png)

You can access each datapack's direct download at `https://github.com/mcpeachpies/mcpeachpies-datapacks/releases/latest/download/mcpeachpies_datapack_name.zip`