### PR TITLE
Remove pull request event from action

### DIFF
--- a/.github/workflows/compress-and-release.yml
+++ b/.github/workflows/compress-and-release.yml
@@ -3,8 +3,6 @@ name: Compress and Release
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
This should make it so the action no longer runs when pull requests are opened so that it doesn't attempt to create releases for non-merged PRs. You will need to trigger a manual run after merging PRs.