### PR TITLE
Updated juice result items:

### DIFF
--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/apple_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/apple_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:1,Duration:1200},{Id:8,Amplifier:1,Duration:1200},{Id:23,Amplifier:1}]}"
+              "tag": "{CustomPotionColor:16626446,CustomPotionEffects:[{Id:1,Duration:1200},{Id:8,Amplifier:1,Duration:1200},{Id:23,Amplifier:3}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beer.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beer.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:4,Duration:600},{Id:9,Amplifier:1,Duration:340},{Id:23,Amplifier:1}]}"
+              "tag": "{CustomPotionColor:16499969,CustomPotionEffects:[{Id:4,Duration:600},{Id:9,Amplifier:1,Duration:340},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beetroot_cream.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beetroot_cream.json
@@ -42,7 +42,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:21,Duration:3600},{Id:23,Amplifier:2}]}"
+              "tag": "{CustomPotionColor:12082863,CustomPotionEffects:[{Id:21,Duration:3600},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beetroot_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/beetroot_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:21,Duration:1800},{Id:23}]}"
+              "tag": "{CustomPotionColor:13179962,CustomPotionEffects:[{Id:21,Duration:1800},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/cactus_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/cactus_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:11,Duration:1800},{Id:23}]}"
+              "tag": "{CustomPotionColor:11523706,CustomPotionEffects:[{Id:11,Duration:1800},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/carrot_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/carrot_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:12,Duration:1200},{Id:16,Duration:1200},{Id:23,Amplifier:2}]}"
+              "tag": "{CustomPotionColor:15895325,CustomPotionEffects:[{Id:12,Duration:2400},{Id:16,Duration:2400},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/chorus_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/chorus_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:25,Duration:250},{Id:23}]}"
+              "tag": "{CustomPotionColor:16777215,CustomPotionEffects:[{Id:25,Duration:250},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/concentrated_cactus_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/concentrated_cactus_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:11,Amplifier:1,Duration:1800},{Id:9,Amplifier:1,Duration:180},{Id:23,Amplifier:1}]}"
+              "tag": "{CustomPotionColor:10799473,CustomPotionEffects:[{Id:11,Amplifier:1,Duration:1800},{Id:9,Amplifier:0,Duration:180},{Id:23,Amplifier:3}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/glowing_pumpkin_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/glowing_pumpkin_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:3,Amplifier:1,Duration:3000},{Id:24,Duration:3000},{Id:23,Amplifier:2}]}"
+              "tag": "{CustomPotionColor:15372035,CustomPotionEffects:[{Id:3,Amplifier:1,Duration:3000},{Id:24,Duration:3000},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/hot_chocolate.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/hot_chocolate.json
@@ -42,7 +42,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:1,Amplifier:2,Duration:360},{Id:23,Amplifier:1}]}"
+              "tag": "{CustomPotionColor:6376483,CustomPotionEffects:[{Id:1,Amplifier:2,Duration:360},{Id:23,Amplifier:3}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/magic_mushroom_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/magic_mushroom_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:9,Duration:600},{Id:8,Amplifier:5,Duration:1200},{Id:4,Duration:1200},{Id:24,Duration:1200},{Id:19,Duration:1200},{Id:10,Duration:1200},{Id:23}]}"
+              "tag": "{CustomPotionColor:9581977,CustomPotionEffects:[{Id:9,Duration:600},{Id:8,Amplifier:5,Duration:1200},{Id:4,Duration:1200},{Id:24,Duration:1200},{Id:19,Duration:1200},{Id:10,Duration:1200,Amplifier:1},{Id:23,Amplifier:3}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/melon_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/melon_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:6},{Id:23,Amplifier:4}]}"
+              "tag": "{CustomPotionColor:16668757,CustomPotionEffects:[{Id:6},{Id:23,Amplifier:9}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/ocean_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/ocean_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:29,Duration:2400},{Id:30,Duration:2400},{Id:23}]}"
+              "tag": "{CustomPotionColor:6149286,CustomPotionEffects:[{Id:29,Duration:2400},{Id:30,Duration:2400},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/popping_chorus_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/popping_chorus_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:25,Amplifier:48,Duration:24},{Id:23}]}"
+              "tag": "{CustomPotionColor:16245503,CustomPotionEffects:[{Id:25,Amplifier:48,Duration:24},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/pumpkin_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/pumpkin_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:3,Duration:2400},{Id:23,Amplifier:2}]}"
+              "tag": "{CustomPotionColor:15372035,CustomPotionEffects:[{Id:3,Duration:2400},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_apple_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_apple_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:1,Duration:2400},{Id:8,Amplifier:1,Duration:2400},{Id:22,Duration:2400},{Id:10,Amplifier:1,Duration:100},{Id:23}]}"
+              "tag": "{CustomPotionColor:16761924,CustomPotionEffects:[{Id:1,Duration:2400},{Id:8,Amplifier:1,Duration:2400},{Id:22,Duration:2400},{Id:10,Amplifier:1,Duration:100},{Id:23,Amplifier:1}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_carrot_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_carrot_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:12,Duration:9600},{Id:16,Duration:9600},{Id:23,Amplifier:2}]}"
+              "tag": "{CustomPotionColor:15895325,CustomPotionEffects:[{Id:12,Duration:9600},{Id:16,Duration:9600},{Id:23,Amplifier:5}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_melon_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/shiny_melon_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:6,Amplifier:3},{Id:23,Amplifier:4}]}"
+              "tag": "{CustomPotionColor:16668757,CustomPotionEffects:[{Id:6,Amplifier:1},{Id:23,Amplifier:9}]}"
             }
           ]
         }

--- a/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/sparkling_apple_juice.json
+++ b/power_juices/mcpeachpies_power_juices/data/mcpeachpies_power_juices/loot_tables/recipes/sparkling_apple_juice.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "minecraft:set_nbt",
-              "tag": "{CustomPotionEffects:[{Id:1,Amplifier:1,Duration:2400},{Id:8,Amplifier:1,Duration:2400},{Id:22,Amplifier:3,Duration:2400},{Id:10,Amplifier:4,Duration:6000},{Id:12,Duration:6000},{Id:11,Duration:6000},{Id:23,Amplifier:9}]}"
+              "tag": "{CustomPotionColor:16765009,CustomPotionEffects:[{Id:1,Amplifier:1,Duration:2400},{Id:8,Amplifier:1,Duration:2400},{Id:22,Amplifier:3,Duration:2400},{Id:10,Amplifier:4,Duration:6000},{Id:12,Duration:6000},{Id:11,Duration:6000},{Id:23,Amplifier:19}]}"
             }
           ]
         }


### PR DESCRIPTION
- Saturation levels doubled to resemble specification
- Added juice colours
- Carrot juice effects changed from 1:00 -> 2:00 by specificiation
- Shiny melon juice reduced from 8 hearts to 4 hearts by specification
- Could not change regular melon juice to 1 heart only. 2 hearts is fine though
- Changed beer to 6 hunger points from 2 to add some nutritional value
- Concentrated cactus juice nausea effects reduced from lvl 2 to lvl 1 to better match my initial vision on the juice
- Magic Mushroom Juice regen level increased to 2 to perfectly counteract the poison effect to just have the damage effect, not the actual damage.
- Magic Mushroom Juice hunger points buffed from 2 to 4.